### PR TITLE
feat: add bm bookmark module with fzf+rg integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 zsh/local.zsh
 zsh/local.d/
+zsh/bookmarks

--- a/init.zsh
+++ b/init.zsh
@@ -56,9 +56,12 @@ typeset -ga _ZSH_CONFIG_DEFAULT_MODULES=(
   til
   search
   ws
+  bm
 )
 
-if (( ! ${+ZSH_CONFIG_MODULES} )); then
+# Respect a user-pinned list (ZSH_CONFIG_MODULES set before sourcing this file),
+# but always refresh from defaults on re-source so new modules are picked up.
+if (( ! ${+ZSH_CONFIG_MODULES_PINNED} )); then
   typeset -ga ZSH_CONFIG_MODULES
   ZSH_CONFIG_MODULES=("${_ZSH_CONFIG_DEFAULT_MODULES[@]}")
 fi

--- a/zsh/bm.zsh
+++ b/zsh/bm.zsh
@@ -1,0 +1,58 @@
+# Bookmarks file lives inside the repo, gitignored alongside local.zsh
+typeset -g BM_FILE="$ZSH_CONFIG_ROOT/zsh/bookmarks"
+[[ -f "$BM_FILE" ]] || touch "$BM_FILE"
+
+# Auto-export all bookmarks as env vars at init
+function _bm_export_all() {
+  local name path
+  while IFS='=' read -r name path; do
+    [[ -z "$name" || "$name" == \#* ]] && continue
+    export "${name}=${path}"
+  done < "$BM_FILE"
+}
+_bm_export_all
+
+function bm() {
+  case "$1" in
+    add) _bm_add "${@:2}" ;;
+    rm)  _bm_rm ;;
+    ls)  _bm_ls ;;
+    *)   _bm_pick ;;
+  esac
+}
+
+# fzf picker → cd; rg --files for rich directory preview
+function _bm_pick() {
+  local line
+  line=$(grep -v '^[[:space:]]*#' "$BM_FILE" \
+    | fzf --prompt="bookmark> " \
+          --preview='rg --files "$(cut -d= -f2- <<< {})" 2>/dev/null | head -50')
+  [[ -z "$line" ]] && return
+  cd "${line#*=}"
+}
+
+# add bookmark
+function _bm_add() {
+  local name="${1:-$(basename "$PWD")}"
+  local path="${2:-$PWD}"
+  path="${path/#\~/$HOME}"
+  sed -i '' "/^${name}=/d" "$BM_FILE"
+  printf '%s=%s\n' "$name" "$path" >> "$BM_FILE"
+  export "${name}=${path}"
+  echo "bookmarked: $name → $path"
+}
+
+# remove via fzf picker
+function _bm_rm() {
+  local name
+  name=$(cut -d= -f1 "$BM_FILE" | fzf --prompt="remove> ")
+  [[ -z "$name" ]] && return
+  sed -i '' "/^${name}=/d" "$BM_FILE"
+  unset "$name"
+  echo "removed: $name"
+}
+
+# list all (column aligns name and path neatly)
+function _bm_ls() {
+  column -t -s= "$BM_FILE"
+}

--- a/zsh/local.example.zsh
+++ b/zsh/local.example.zsh
@@ -18,3 +18,8 @@
 # Machine-specific or work-only settings belong here.
 # export WORKON_HOME="$HOME/venvs"
 # alias workon='source "$WORKON_HOME/project/bin/activate"'
+
+# Project path bookmarks — use the bm module instead of manual exports.
+# Run these once to populate zsh/bookmarks, then remove the export lines:
+# bm add avlbe ~/Projects/arrival/arrival-backend
+# bm add cm_home ~/Projects/consolidated_repo/configmgmt


### PR DESCRIPTION
Adds a named directory bookmark manager backed by zsh/bookmarks (gitignored).
Bookmarks are auto-exported as env vars at shell init so existing $var-style
navigation keeps working. Includes fzf picker with rg --files preview, and
add/rm/ls subcommands.

Also fixes re-sourcing so new default modules are picked up without opening
a new shell (zsh/bm.zsh, init.zsh, .gitignore, zsh/local.example.zsh).

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>