### PR TITLE
feat: add secret manager feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 zsh/local.zsh
 zsh/local.d/
 zsh/bookmarks
+zsh/secrets

--- a/init.zsh
+++ b/init.zsh
@@ -57,6 +57,7 @@ typeset -ga _ZSH_CONFIG_DEFAULT_MODULES=(
   search
   ws
   bm
+  sec
 )
 
 # Respect a user-pinned list (ZSH_CONFIG_MODULES set before sourcing this file),

--- a/zsh/local.example.zsh
+++ b/zsh/local.example.zsh
@@ -23,3 +23,8 @@
 # Run these once to populate zsh/bookmarks, then remove the export lines:
 # bm add avlbe ~/Projects/arrival/arrival-backend
 # bm add cm_home ~/Projects/consolidated_repo/configmgmt
+
+# Credentials — use the sec module instead of manual exports.
+# Run these once to populate zsh/secrets, then remove the export lines:
+# sec add GITLAB_ACCESS_TOKEN
+# sec add JIRA_ACCESS_TOKEN

--- a/zsh/sec.zsh
+++ b/zsh/sec.zsh
@@ -1,0 +1,76 @@
+typeset -g SEC_FILE="$ZSH_CONFIG_ROOT/zsh/secrets"
+[[ -f "$SEC_FILE" ]] || touch "$SEC_FILE"
+
+# Auto-export all secrets as env vars at init
+while IFS='=' read -r _sec_name _sec_val; do
+  [[ -z "$_sec_name" || "$_sec_name" == \#* ]] && continue
+  export "${_sec_name}=${_sec_val}"
+done < "$SEC_FILE"
+unset _sec_name _sec_val
+
+function sec() {
+  case "$1" in
+    add) _sec_add "${@:2}" ;;
+    rm)  _sec_rm ;;
+    ls)  _sec_ls ;;
+    *)   _sec_pick ;;
+  esac
+}
+
+function _sec_keys() {
+  cut -d= -f1 "$SEC_FILE" | grep -v '^[[:space:]]*#' | grep -v '^$'
+}
+
+# fzf picker — keys only
+# Enter → copy value to clipboard; Ctrl-e → export in current shell
+function _sec_pick() {
+  local out action key val
+
+  out=$(_sec_keys | fzf --prompt="secret> " \
+    --expect=ctrl-e \
+    --height=40% --layout=reverse \
+    --header='Enter: copy | Ctrl-e: export')
+
+  [[ -z "$out" ]] && return
+  action=$(head -1 <<< "$out")
+  key=$(tail -1 <<< "$out")
+  [[ -z "$key" ]] && return
+  val=$(grep "^${key}=" "$SEC_FILE" | cut -d= -f2-)
+  if [[ "$action" == "ctrl-e" ]]; then
+    export "${key}=${val}"
+    echo "exported: $key"
+  else
+    printf '%s' "$val" | pbcopy
+    echo "copied: $key"
+  fi
+}
+
+# add secret; prompts silently if value not provided
+function _sec_add() {
+  local name="$1" val="$2"
+  [[ -z "$name" ]] && { echo "usage: sec add NAME [value]"; return 1 }
+  if [[ -z "$val" ]]; then
+    printf 'value for %s: ' "$name"
+    read -rs val
+    echo
+  fi
+  sed -i '' "/^${name}=/d" "$SEC_FILE"
+  printf '%s=%s\n' "$name" "$val" >> "$SEC_FILE"
+  export "${name}=${val}"
+  echo "saved: $name"
+}
+
+# remove via fzf picker
+function _sec_rm() {
+  local name
+  name=$(_sec_keys | fzf --prompt="remove secret> ")
+  [[ -z "$name" ]] && return
+  sed -i '' "/^${name}=/d" "$SEC_FILE"
+  unset "$name"
+  echo "removed: $name"
+}
+
+# list key names only
+function _sec_ls() {
+  _sec_keys
+}


### PR DESCRIPTION
This pull request introduces a new secrets management module for Zsh, making it easier and safer to handle sensitive environment variables. The new `sec` module allows users to securely store, retrieve, export, and manage secrets directly from the shell, replacing the need for manual environment variable exports. Documentation and configuration files are updated to reflect this change.

**Secrets management improvements:**

* Added a new `zsh/sec.zsh` module providing commands to add, remove, list, and pick secrets, with integration for secure clipboard copying and environment variable export. Secrets are stored in a dedicated file and auto-exported at shell startup.
* Enabled the `sec` module by default in the Zsh configuration, ensuring it's loaded for all users. (`init.zsh`)

**Documentation and onboarding:**

* Updated `zsh/local.example.zsh` to instruct users to use the new `sec` module for credentials instead of manual exports, including sample commands for adding secrets.