### PR TITLE
feat: add secret manager and navigator features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 zsh/local.zsh
 zsh/local.d/
 zsh/bookmarks
+zsh/secrets

--- a/init.zsh
+++ b/init.zsh
@@ -57,6 +57,7 @@ typeset -ga _ZSH_CONFIG_DEFAULT_MODULES=(
   search
   ws
   bm
+  sec
 )
 
 # Respect a user-pinned list (ZSH_CONFIG_MODULES set before sourcing this file),

--- a/zsh/local.example.zsh
+++ b/zsh/local.example.zsh
@@ -23,3 +23,8 @@
 # Run these once to populate zsh/bookmarks, then remove the export lines:
 # bm add avlbe ~/Projects/arrival/arrival-backend
 # bm add cm_home ~/Projects/consolidated_repo/configmgmt
+
+# Credentials — use the sec module instead of manual exports.
+# Run these once to populate zsh/secrets, then remove the export lines:
+# sec add GITLAB_ACCESS_TOKEN
+# sec add JIRA_ACCESS_TOKEN

--- a/zsh/sec.zsh
+++ b/zsh/sec.zsh
@@ -1,0 +1,76 @@
+typeset -g SEC_FILE="$ZSH_CONFIG_ROOT/zsh/secrets"
+[[ -f "$SEC_FILE" ]] || touch "$SEC_FILE"
+
+# Auto-export all secrets as env vars at init
+while IFS='=' read -r _sec_name _sec_val; do
+  [[ -z "$_sec_name" || "$_sec_name" == \#* ]] && continue
+  export "${_sec_name}=${_sec_val}"
+done < "$SEC_FILE"
+unset _sec_name _sec_val
+
+function sec() {
+  case "$1" in
+    add) _sec_add "${@:2}" ;;
+    rm)  _sec_rm ;;
+    ls)  _sec_ls ;;
+    *)   _sec_pick ;;
+  esac
+}
+
+function _sec_keys() {
+  cut -d= -f1 "$SEC_FILE" | grep -v '^[[:space:]]*#' | grep -v '^$'
+}
+
+# fzf picker — keys only
+# Enter → copy value to clipboard; Ctrl-e → export in current shell
+function _sec_pick() {
+  local out action key val
+
+  out=$(_sec_keys | fzf --prompt="secret> " \
+    --expect=ctrl-e \
+    --height=40% --layout=reverse \
+    --header='Enter: copy | Ctrl-e: export')
+
+  [[ -z "$out" ]] && return
+  action=$(head -1 <<< "$out")
+  key=$(tail -1 <<< "$out")
+  [[ -z "$key" ]] && return
+  val=$(grep "^${key}=" "$SEC_FILE" | cut -d= -f2-)
+  if [[ "$action" == "ctrl-e" ]]; then
+    export "${key}=${val}"
+    echo "exported: $key"
+  else
+    printf '%s' "$val" | pbcopy
+    echo "copied: $key"
+  fi
+}
+
+# add secret; prompts silently if value not provided
+function _sec_add() {
+  local name="$1" val="$2"
+  [[ -z "$name" ]] && { echo "usage: sec add NAME [value]"; return 1 }
+  if [[ -z "$val" ]]; then
+    printf 'value for %s: ' "$name"
+    read -rs val
+    echo
+  fi
+  sed -i '' "/^${name}=/d" "$SEC_FILE"
+  printf '%s=%s\n' "$name" "$val" >> "$SEC_FILE"
+  export "${name}=${val}"
+  echo "saved: $name"
+}
+
+# remove via fzf picker
+function _sec_rm() {
+  local name
+  name=$(_sec_keys | fzf --prompt="remove secret> ")
+  [[ -z "$name" ]] && return
+  sed -i '' "/^${name}=/d" "$SEC_FILE"
+  unset "$name"
+  echo "removed: $name"
+}
+
+# list key names only
+function _sec_ls() {
+  _sec_keys
+}

--- a/zsh/shell.zsh
+++ b/zsh/shell.zsh
@@ -13,3 +13,81 @@ export PATH="$HOME/.local/bin:$PATH"
 # --- General aliases ---
 alias resource="source ~/.zshrc"
 alias tf="terraform"
+
+# ---------------------------------------------------------------------------
+# falias - fuzzy alias picker
+#
+# Usage:
+#   falias        fzf picker over all aliases
+#                 Enter puts expansion in prompt buffer (edit before running)
+#                 Ctrl-y copies expansion to clipboard
+# ---------------------------------------------------------------------------
+function falias() {
+  local out action sel expansion
+  local -a lines=()
+
+  # $aliases is a zsh built-in associative array — no parsing needed
+  for name val in ${(kv)aliases}; do
+    lines+=("$name  →  $val")
+  done
+
+  out=$(printf '%s\n' "${(o)lines[@]}" \
+    | fzf --prompt="alias> " \
+          --expect=ctrl-y \
+          --height=40% --layout=reverse \
+          --header='Enter: edit+run | Ctrl-y: copy')
+
+  [[ -z "$out" ]] && return
+  local -a result=("${(@f)out}")
+  action="${result[1]}" sel="${result[2]}"
+  [[ -z "$sel" ]] && return
+  expansion="${sel#*  →  }"
+
+  if [[ "$action" == "ctrl-y" ]]; then
+    printf '%s' "$expansion" | pbcopy
+    echo "copied: $expansion"
+  else
+    print -z "$expansion"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# fenv - fuzzy env var picker
+#
+# Usage:
+#   fenv          fzf picker over exported env vars (sorted)
+#                 Enter copies value to clipboard
+#                 Ctrl-e re-exports the var in the current shell
+# ---------------------------------------------------------------------------
+function fenv() {
+  local out action line key val
+  local -a lines=()
+
+  # $parameters is a zsh built-in — filter to exported vars only
+  for name in ${(k)parameters[(R)*export*]}; do
+    lines+=("$name=${(P)name}")
+  done
+
+  out=$(printf '%s\n' "${(o)lines[@]}" \
+    | fzf --prompt="env> " \
+          --expect=ctrl-e \
+          --height=40% --layout=reverse \
+          --preview='echo {} | cut -d= -f2- | tr ":" "\n"' \
+          --preview-window='right:40%:wrap' \
+          --header='Enter: copy value | Ctrl-e: re-export')
+
+  [[ -z "$out" ]] && return
+  local -a result=("${(@f)out}")
+  action="${result[1]}" line="${result[2]}"
+  [[ -z "$line" ]] && return
+  key="${line%%=*}"
+  val="${line#*=}"
+
+  if [[ "$action" == "ctrl-e" ]]; then
+    export "${key}=${val}"
+    echo "exported: $key"
+  else
+    printf '%s' "$val" | pbcopy
+    echo "copied: $key"
+  fi
+}


### PR DESCRIPTION
This pull request introduces a new secrets management module for Zsh, improves environment variable and alias handling with fuzzy finders, and updates documentation to guide users toward the new approach. The most notable changes are the addition of the `sec` module for secure secret storage and retrieval, and new functions for interactively managing aliases and environment variables.

**Secrets management:**

* Added a new `sec` module (`zsh/sec.zsh`) for managing secrets from a dedicated file (`zsh/secrets`). This module auto-exports secrets as environment variables at shell init, and provides commands to add, remove, list, and interactively select secrets using `fzf`. 
* Enabled the `sec` module by default in the Zsh configuration, ensuring it loads automatically.
* Updated the example local configuration (`zsh/local.example.zsh`) to recommend using the `sec` module for credentials instead of manual exports, including usage instructions.

**Fuzzy finders for aliases and env vars:**

* Added `falias`, a fuzzy finder over all aliases, allowing users to insert or copy alias expansions interactively.
* Added `fenv`, a fuzzy picker for exported environment variables, enabling users to copy values or re-export variables in the current shell.