### PR TITLE
#12: inline delete binding in main bm picker

### DIFF
--- a/zsh/bm.zsh
+++ b/zsh/bm.zsh
@@ -2,6 +2,28 @@
 typeset -g BM_FILE="$ZSH_CONFIG_ROOT/zsh/bookmarks"
 [[ -f "$BM_FILE" ]] || touch "$BM_FILE"
 
+function _bm_delete_entry() {
+  emulate -L zsh
+
+  local name="$1"
+  local line
+  local -a lines
+
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    if [[ "$line" == *=* && "${line%%=*}" == "$name" ]]; then
+      continue
+    fi
+
+    lines+=("$line")
+  done < "$BM_FILE"
+
+  : > "$BM_FILE" || return 1
+
+  if (( ${#lines[@]} > 0 )); then
+    printf '%s\n' "${lines[@]}" > "$BM_FILE" || return 1
+  fi
+}
+
 # Auto-export all bookmarks as env vars at init
 function _bm_export_all() {
   local name path
@@ -23,12 +45,18 @@ function bm() {
 
 # fzf picker → cd; rg --files for rich directory preview
 function _bm_pick() {
-  local line
+  local line path
   line=$(grep -v '^[[:space:]]*#' "$BM_FILE" \
     | fzf --prompt="bookmark> " \
+          --height=40% --layout=reverse \
+          --delimiter='=' \
+          --header='Enter: cd | Ctrl-d: delete bookmark' \
+          --exit-0 \
+          --bind="ctrl-d:execute-silent(zsh -fc 'ZSH_CONFIG_ROOT=\"\$1\"; source \"\$ZSH_CONFIG_ROOT/zsh/bm.zsh\"; _bm_delete_entry \"\$2\"' _ \"$ZSH_CONFIG_ROOT\" \"{1}\")+reload(grep -v '^[[:space:]]*#' \"$BM_FILE\")" \
           --preview='rg --files "$(cut -d= -f2- <<< {})" 2>/dev/null | head -50')
   [[ -z "$line" ]] && return
-  cd "${line#*=}"
+  path="${line#*=}"
+  cd "${~path}"
 }
 
 # add bookmark
@@ -47,7 +75,7 @@ function _bm_rm() {
   local name
   name=$(cut -d= -f1 "$BM_FILE" | fzf --prompt="remove> ")
   [[ -z "$name" ]] && return
-  sed -i '' "/^${name}=/d" "$BM_FILE"
+  _bm_delete_entry "$name" || return 1
   unset "$name"
   echo "removed: $name"
 }


### PR DESCRIPTION
fixes #12

## Summary
- add Ctrl-D inline deletion to the main bm picker
- reuse the shared bookmark deletion helper for picker and bm rm flows
- keep Enter as the existing cd action and reload the picker after deletion

## Validation
- zsh -n zsh/bm.zsh
- helper deletion test preserved remaining entries
- deleting the final bookmark leaves the file empty cleanly