### PR TITLE
#9: bm should not export bookmark names as shell variables

### DIFF
--- a/zsh/bm.zsh
+++ b/zsh/bm.zsh
@@ -23,17 +23,6 @@ function _bm_delete_entry() {
     printf '%s\n' "${lines[@]}" > "$BM_FILE" || return 1
   fi
 }
-
-# Auto-export all bookmarks as env vars at init
-function _bm_export_all() {
-  local name path
-  while IFS='=' read -r name path; do
-    [[ -z "$name" || "$name" == \#* ]] && continue
-    export "${name}=${path}"
-  done < "$BM_FILE"
-}
-_bm_export_all
-
 function bm() {
   case "$1" in
     add) _bm_add "${@:2}" ;;
@@ -63,10 +52,10 @@ function _bm_pick() {
 function _bm_add() {
   local name="${1:-$(basename "$PWD")}"
   local path="${2:-$PWD}"
-  path="${path/#\~/$HOME}"
+
+  path="${~path:A}"
   sed -i '' "/^${name}=/d" "$BM_FILE"
   printf '%s=%s\n' "$name" "$path" >> "$BM_FILE"
-  export "${name}=${path}"
   echo "bookmarked: $name → $path"
 }
 
@@ -76,7 +65,6 @@ function _bm_rm() {
   name=$(cut -d= -f1 "$BM_FILE" | fzf --prompt="remove> ")
   [[ -z "$name" ]] && return
   _bm_delete_entry "$name" || return 1
-  unset "$name"
   echo "removed: $name"
 }
 

--- a/zsh/local.example.zsh
+++ b/zsh/local.example.zsh
@@ -20,11 +20,11 @@
 # alias workon='source "$WORKON_HOME/project/bin/activate"'
 
 # Project path bookmarks — use the bm module instead of manual exports.
-# Run these once to populate zsh/bookmarks, then remove the export lines:
+# Run these once to populate zsh/bookmarks:
 # bm add avlbe ~/Projects/arrival/arrival-backend
 # bm add cm_home ~/Projects/consolidated_repo/configmgmt
 
 # Credentials — use the sec module instead of manual exports.
-# Run these once to populate zsh/secrets, then remove the export lines:
+# Run these once to populate zsh/secrets:
 # sec add GITLAB_ACCESS_TOKEN
 # sec add JIRA_ACCESS_TOKEN


### PR DESCRIPTION
fixes #9

## Summary
- stop exporting bookmark labels at bm module load time
- stop exporting and unsetting bookmark names during bm add and bm rm flows
- update the local example comments so bookmarks and secrets are described as one-time setup commands instead of export lines

## Validation
- zsh -n zsh/bm.zsh
- sourced the module with aws-training=/tmp in zsh/bookmarks
- confirmed the module loads cleanly and aws-training is not exported