### PR TITLE
fix(#8): bm/sec should not depend on brittle sed invocation

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -60,6 +60,9 @@ typeset -ga _ZSH_CONFIG_DEFAULT_MODULES=(
   sec
 )
 
+# Load shared state helpers before modules that rely on file mutation helpers.
+[[ -f "$ZSH_CONFIG_ROOT/zsh/state.zsh" ]] && source "$ZSH_CONFIG_ROOT/zsh/state.zsh"
+
 # Respect a user-pinned list (ZSH_CONFIG_MODULES set before sourcing this file),
 # but always refresh from defaults on re-source so new modules are picked up.
 if (( ! ${+ZSH_CONFIG_MODULES_PINNED} )); then

--- a/zsh/bm.zsh
+++ b/zsh/bm.zsh
@@ -6,22 +6,8 @@ function _bm_delete_entry() {
   emulate -L zsh
 
   local name="$1"
-  local line
-  local -a lines
 
-  while IFS= read -r line || [[ -n "$line" ]]; do
-    if [[ "$line" == *=* && "${line%%=*}" == "$name" ]]; then
-      continue
-    fi
-
-    lines+=("$line")
-  done < "$BM_FILE"
-
-  : > "$BM_FILE" || return 1
-
-  if (( ${#lines[@]} > 0 )); then
-    printf '%s\n' "${lines[@]}" > "$BM_FILE" || return 1
-  fi
+  _zsh_toolkit_kv_update_file "$BM_FILE" "$name" "" delete
 }
 function bm() {
   case "$1" in
@@ -54,8 +40,7 @@ function _bm_add() {
   local path="${2:-$PWD}"
 
   path="${~path:A}"
-  sed -i '' "/^${name}=/d" "$BM_FILE"
-  printf '%s=%s\n' "$name" "$path" >> "$BM_FILE"
+  _zsh_toolkit_kv_update_file "$BM_FILE" "$name" "$path" set
   echo "bookmarked: $name → $path"
 }
 

--- a/zsh/sec.zsh
+++ b/zsh/sec.zsh
@@ -57,8 +57,7 @@ function _sec_add() {
     read -rs val
     echo
   fi
-  sed -i '' "/^${name}=/d" "$SEC_FILE"
-  printf '%s=%s\n' "$name" "$val" >> "$SEC_FILE"
+  _zsh_toolkit_kv_update_file "$SEC_FILE" "$name" "$val" set
   export "${name}=${val}"
   echo "saved: $name"
 }
@@ -68,7 +67,7 @@ function _sec_rm() {
   local name
   name=$(_sec_keys | fzf --prompt="remove secret> ")
   [[ -z "$name" ]] && return
-  sed -i '' "/^${name}=/d" "$SEC_FILE"
+  _zsh_toolkit_kv_update_file "$SEC_FILE" "$name" "" delete
   unset "$name"
   echo "removed: $name"
 }

--- a/zsh/state.zsh
+++ b/zsh/state.zsh
@@ -1,0 +1,44 @@
+# Shared helpers for tiny key=value state files.
+
+function _zsh_toolkit_kv_update_file() {
+  emulate -L zsh
+
+  local file="$1"
+  local key="$2"
+  local value="${3:-}"
+  local mode="${4:-set}"  # set | delete
+  local tmp found=0 line current_key
+
+  tmp="$(/usr/bin/mktemp "${file}.XXXXXX")" || return 1
+
+  {
+    while IFS= read -r line || [[ -n "$line" ]]; do
+      if [[ -z "$line" || "$line" == \#* ]]; then
+        printf '%s\n' "$line"
+        continue
+      fi
+
+      current_key="${line%%=*}"
+      if [[ "$current_key" == "$key" ]]; then
+        found=1
+        [[ "$mode" == "delete" ]] && continue
+        printf '%s=%s\n' "$key" "$value"
+        continue
+      fi
+
+      printf '%s\n' "$line"
+    done < "$file"
+
+    if [[ "$mode" == "set" && $found -eq 0 ]]; then
+      printf '%s=%s\n' "$key" "$value"
+    fi
+  } > "$tmp" || {
+    /bin/rm -f "$tmp"
+    return 1
+  }
+
+  /bin/mv "$tmp" "$file" || {
+    /bin/rm -f "$tmp"
+    return 1
+  }
+}


### PR DESCRIPTION
fixes #8

## Summary
- replace sed-based mutation with a shared Zsh key-value rewrite helper
- keep the current flat-file storage model for bookmarks and secrets
- preserve comments and blank lines during updates

## Verification
- zsh -n init.zsh zsh/state.zsh zsh/bm.zsh zsh/sec.zsh
- helper integration test for set/delete on bookmarks and secrets
- confirmed no sed-based mutation remains in bm/sec paths