### PR TITLE
feat(#10): add a proper help surface for toolkit commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ alias gs='git status'
 
 Editor-based helpers use `ZSH_TOOLKIT_EDITOR`, then `EDITOR`, then `VISUAL`, then `nvim` when available, with `vi` as the final fallback.
 
+Use `zt help` to see the toolkit commands, and `zt help <command>` for command-specific usage.
+
 In the `til` and `todo` pickers, press `Ctrl-N` to create a new note from the current query.
 
 ## Modules
@@ -84,6 +86,7 @@ The default modules are:
 - `k8s`
 - `til`
 - `search`
+- `zt`
 - `ws`
 
 If you want fewer modules, set this before sourcing `init.zsh`:

--- a/init.zsh
+++ b/init.zsh
@@ -55,6 +55,7 @@ typeset -ga _ZSH_CONFIG_DEFAULT_MODULES=(
   k8s
   til
   search
+  zt
   ws
   bm
   sec

--- a/zsh/bm.zsh
+++ b/zsh/bm.zsh
@@ -9,8 +9,29 @@ function _bm_delete_entry() {
 
   _zsh_toolkit_kv_update_file "$BM_FILE" "$name" "" delete
 }
+
+function bm-usage() {
+  case "${1:-}" in
+    "")
+      echo "bm - bookmarks"
+      echo
+      echo "Usage:"
+      echo "  bm                 open the bookmark picker"
+      echo "  bm add [name] [path]  add or update a bookmark"
+      echo "  bm rm              remove a bookmark"
+      echo "  bm ls              list bookmarks"
+      echo "  bm help [subcommand]  show help"
+      ;;
+    add) echo "usage: bm add [name] [path]" ;;
+    rm)  echo "usage: bm rm" ;;
+    ls)  echo "usage: bm ls" ;;
+    *)   echo "bm: unknown subcommand: $1"; return 1 ;;
+  esac
+}
+
 function bm() {
   case "$1" in
+    help|-h|--help) bm-usage "${@:2}" ;;
     add) _bm_add "${@:2}" ;;
     rm)  _bm_rm ;;
     ls)  _bm_ls ;;

--- a/zsh/sec.zsh
+++ b/zsh/sec.zsh
@@ -8,8 +8,28 @@ while IFS='=' read -r _sec_name _sec_val; do
 done < "$SEC_FILE"
 unset _sec_name _sec_val
 
+function sec-usage() {
+  case "${1:-}" in
+    "")
+      echo "sec - secrets"
+      echo
+      echo "Usage:"
+      echo "  sec                 open the secret picker"
+      echo "  sec add NAME [value]  add or update a secret"
+      echo "  sec rm              remove a secret"
+      echo "  sec ls              list secret names"
+      echo "  sec help [subcommand]  show help"
+      ;;
+    add) echo "usage: sec add NAME [value]" ;;
+    rm)  echo "usage: sec rm" ;;
+    ls)  echo "usage: sec ls" ;;
+    *)   echo "sec: unknown subcommand: $1"; return 1 ;;
+  esac
+}
+
 function sec() {
   case "$1" in
+    help|-h|--help) sec-usage "${@:2}" ;;
     add) _sec_add "${@:2}" ;;
     rm)  _sec_rm ;;
     ls)  _sec_ls ;;

--- a/zsh/til.zsh
+++ b/zsh/til.zsh
@@ -27,6 +27,78 @@ function _notes_delete_markdown() {
   rm -f -- "$file"
 }
 
+function til-usage() {
+  case "${1:-}" in
+    "")
+      echo "til - TIL notes"
+      echo
+      echo "Usage:"
+      echo "  til [topic]   open or create a note in ~/.til/"
+      ;;
+    *) echo "usage: til [topic]" ;;
+  esac
+}
+
+function tilv-usage() {
+  case "${1:-}" in
+    "")
+      echo "tilv - TIL note viewer"
+      echo
+      echo "Usage:"
+      echo "  tilv [topic]  view a note in ~/.til/"
+      ;;
+    *) echo "usage: tilv [topic]" ;;
+  esac
+}
+
+function todo-usage() {
+  case "${1:-}" in
+    "")
+      echo "todo - TODO notes"
+      echo
+      echo "Usage:"
+      echo "  todo [topic]  open or create a note in ~/.todo/"
+      ;;
+    *) echo "usage: todo [topic]" ;;
+  esac
+}
+
+function todov-usage() {
+  case "${1:-}" in
+    "")
+      echo "todov - TODO note viewer"
+      echo
+      echo "Usage:"
+      echo "  todov [topic]  view a note in ~/.todo/"
+      ;;
+    *) echo "usage: todov [topic]" ;;
+  esac
+}
+
+function tils-usage() {
+  case "${1:-}" in
+    "")
+      echo "tils - search TIL notes"
+      echo
+      echo "Usage:"
+      echo "  tils <query>  search ~/.til/*.md"
+      ;;
+    *) echo "usage: tils <query>" ;;
+  esac
+}
+
+function todos-usage() {
+  case "${1:-}" in
+    "")
+      echo "todos - search TODO notes"
+      echo
+      echo "Usage:"
+      echo "  todos <query>  search ~/.todo/*.md"
+      ;;
+    *) echo "usage: todos <query>" ;;
+  esac
+}
+
 function _notes_pick_markdown() {
   local dir="$1"
   local prompt="$2"
@@ -150,6 +222,9 @@ function _notes_search() {
 #   til <topic>   open (or create) ~/.til/<topic>.md directly
 # ---------------------------------------------------------------------------
 function _til() {
+  case "${1:-}" in
+    help|-h|--help) til-usage; return 0 ;;
+  esac
   _notes_open_or_pick "$HOME/.til" "til > " "_zsh_toolkit_open_in_editor" "$1" true
 }
 
@@ -161,6 +236,9 @@ function _til() {
 #   tilv <topic>   view ~/.til/<topic>.md directly
 # ---------------------------------------------------------------------------
 function _tilv() {
+  case "${1:-}" in
+    help|-h|--help) tilv-usage; return 0 ;;
+  esac
   _notes_open_or_pick "$HOME/.til" "til > " "bat" "$1"
 }
 
@@ -172,6 +250,9 @@ function _tilv() {
 #   todo <topic>   open (or create) ~/.todo/<topic>.md directly
 # ---------------------------------------------------------------------------
 function _todo() {
+  case "${1:-}" in
+    help|-h|--help) todo-usage; return 0 ;;
+  esac
   _notes_open_or_pick "$HOME/.todo" "todo > " "_zsh_toolkit_open_in_editor" "$1" true
 }
 
@@ -183,6 +264,9 @@ function _todo() {
 #   todov <topic>  view ~/.todo/<topic>.md directly
 # ---------------------------------------------------------------------------
 function _todov() {
+  case "${1:-}" in
+    help|-h|--help) todov-usage; return 0 ;;
+  esac
   _notes_open_or_pick "$HOME/.todo" "todo > " "bat" "$1"
 }
 
@@ -194,6 +278,9 @@ function _todov() {
 #   tils <query>    search across all ~/.til/*.md, Enter opens your editor at line
 # ---------------------------------------------------------------------------
 function tils() {
+  case "${1:-}" in
+    help|-h|--help) tils-usage; return 0 ;;
+  esac
   if [[ -z "$1" ]]; then
     _til
     return
@@ -210,6 +297,9 @@ function tils() {
 #   todos <query>   search across all ~/.todo/*.md, Enter opens your editor at line
 # ---------------------------------------------------------------------------
 function todos() {
+  case "${1:-}" in
+    help|-h|--help) todos-usage; return 0 ;;
+  esac
   if [[ -z "$1" ]]; then
     _todo
     return

--- a/zsh/ws.zsh
+++ b/zsh/ws.zsh
@@ -206,7 +206,7 @@ function ws-info() {
 #
 # Usage: ws help [subcommand]
 # ---------------------------------------------------------------------------
-function ws-help() {
+function ws-usage() {
   if [[ $# -eq 0 ]]; then
     echo "ws - workspace manager"
     echo
@@ -232,6 +232,10 @@ function ws-help() {
     help)   echo "usage: ws help [subcommand]" ;;
     *)      echo "ws: unknown subcommand: $1"; return 1 ;;
   esac
+}
+
+function ws-help() {
+  ws-usage "$@"
 }
 
 # ---------------------------------------------------------------------------

--- a/zsh/zt.zsh
+++ b/zsh/zt.zsh
@@ -1,0 +1,91 @@
+# ============================================================
+# ZSH TOOLKIT HELP SURFACE (zt)
+# ============================================================
+
+typeset -ga _ZT_HELP_COMMANDS=(
+  ws
+  bm
+  sec
+  til
+  tilv
+  todo
+  todov
+  tils
+  todos
+)
+
+typeset -gA _ZT_HELP_DESCRIPTIONS
+_ZT_HELP_DESCRIPTIONS=(
+  ws    "workspace manager"
+  bm    "bookmarks"
+  sec   "secrets"
+  til   "open or create a TIL note"
+  tilv  "view a TIL note"
+  todo  "open or create a TODO note"
+  todov "view a TODO note"
+  tils  "search TIL notes"
+  todos "search TODO notes"
+)
+
+typeset -gA _ZT_HELP_USAGE
+_ZT_HELP_USAGE=(
+  ws    "ws-usage"
+  bm    "bm-usage"
+  sec   "sec-usage"
+  til   "til-usage"
+  tilv  "tilv-usage"
+  todo  "todo-usage"
+  todov "todov-usage"
+  tils  "tils-usage"
+  todos "todos-usage"
+)
+
+function zt() {
+  local cmd="${1:-help}"
+
+  case "$cmd" in
+    help|h|-h|--help)
+      zt-help "${@:2}"
+      ;;
+    *)
+      echo "zt: unknown subcommand: $cmd"
+      echo "Run 'zt help' for usage."
+      return 1
+      ;;
+  esac
+}
+
+function zt-help() {
+  emulate -L zsh
+
+  if [[ $# -eq 0 ]]; then
+    local cmd usage
+
+    echo "zt - zsh toolkit"
+    echo
+    echo "Usage: zt help [command]"
+    echo
+    echo "Commands:"
+    for cmd in "${_ZT_HELP_COMMANDS[@]}"; do
+      usage="${_ZT_HELP_USAGE[$cmd]}"
+      whence -w "$usage" >/dev/null 2>&1 || continue
+      printf "  %-8s %s\n" "$cmd" "${_ZT_HELP_DESCRIPTIONS[$cmd]}"
+    done
+    echo
+    echo "Run 'zt help <command>' for command-specific usage."
+    return 0
+  fi
+
+  local usage_func="${_ZT_HELP_USAGE[$1]}"
+  if [[ -z "$usage_func" ]]; then
+    echo "zt: unknown command: $1"
+    return 1
+  fi
+
+  if ! whence -w "$usage_func" >/dev/null 2>&1; then
+    echo "zt: help unavailable for: $1"
+    return 1
+  fi
+
+  "$usage_func"
+}


### PR DESCRIPTION
Adds a central toolkit help surface under `zt`.

Each module keeps its own usage function, and `zt help <command>` routes to the module-specific usage so the help text stays close to the command implementation.

fixes #10
