### PR TITLE
fix(zt): align help surface and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ alias gs='git status'
 
 Editor-based helpers use `ZSH_TOOLKIT_EDITOR`, then `EDITOR`, then `VISUAL`, then `nvim` when available, with `vi` as the final fallback.
 
-Use `zt help` to see the toolkit commands, and `zt help <command>` for command-specific usage.
+Use `zt help` as the canonical toolkit help entrypoint, and `zt help <command>` for command-specific usage.
 
 In the `til` and `todo` pickers, press `Ctrl-N` to create a new note from the current query.
 
@@ -88,6 +88,8 @@ The default modules are:
 - `search`
 - `zt`
 - `ws`
+- `bm`
+- `sec`
 
 If you want fewer modules, set this before sourcing `init.zsh`:
 

--- a/zsh/git.zsh
+++ b/zsh/git.zsh
@@ -23,6 +23,14 @@ alias gst="git stash"
 alias gc="git commit -v"
 alias gss="git status -s"
 
+function gco-usage() {
+  echo "gco - git checkout helper"
+  echo
+  echo "Usage:"
+  echo "  gco           open the branch picker"
+  echo "  gco <branch>  check out a branch directly"
+}
+
 # ---------------------------------------------------------------------------
 # gco - checkout a branch, with fzf picker when no args given
 #
@@ -31,6 +39,10 @@ alias gss="git status -s"
 #   gco <branch>  direct checkout
 # ---------------------------------------------------------------------------
 function gco() {
+  case "${1:-}" in
+    help|-h|--help) gco-usage; return 0 ;;
+  esac
+
   if [[ $# -gt 0 ]]; then
     git checkout "$@"
     return
@@ -44,6 +56,14 @@ function gco() {
   [[ -n "$branch" ]] && git checkout "$branch"
 }
 
+function ga-usage() {
+  echo "ga - git add helper"
+  echo
+  echo "Usage:"
+  echo "  ga         open the file picker"
+  echo "  ga <file>  add one or more paths directly"
+}
+
 # ---------------------------------------------------------------------------
 # ga - stage files, with fzf multi-select picker when no args given
 #
@@ -52,6 +72,10 @@ function gco() {
 #   ga <file>     direct git add
 # ---------------------------------------------------------------------------
 function ga() {
+  case "${1:-}" in
+    help|-h|--help) ga-usage; return 0 ;;
+  esac
+
   if [[ $# -gt 0 ]]; then
     git add "$@"
     return
@@ -102,6 +126,14 @@ function _zsh_toolkit_git_show_diff() {
   git diff HEAD --color=always -- "$file_path"
 }
 
+function gd-usage() {
+  echo "gd - git diff helper"
+  echo
+  echo "Usage:"
+  echo "  gd         open the changed-file picker"
+  echo "  gd <path>  show git diff for one or more paths"
+}
+
 # ---------------------------------------------------------------------------
 # gd - diff files, with fzf picker when no args given
 #
@@ -110,6 +142,10 @@ function _zsh_toolkit_git_show_diff() {
 #   gd <file>     direct git diff
 # ---------------------------------------------------------------------------
 function gd() {
+  case "${1:-}" in
+    help|-h|--help) gd-usage; return 0 ;;
+  esac
+
   if [[ $# -gt 0 ]]; then
     git diff "$@"
     return
@@ -126,6 +162,14 @@ function gd() {
   [[ -n "$file" ]] && _zsh_toolkit_git_show_diff "$selected"
 }
 
+function gl-usage() {
+  echo "gl - git log helper"
+  echo
+  echo "Usage:"
+  echo "  gl         open the commit picker"
+  echo "  gl <args>  run git log --oneline --decorate <args>"
+}
+
 # ---------------------------------------------------------------------------
 # gl - interactive git log picker with rich preview
 #
@@ -134,6 +178,10 @@ function gd() {
 #   gl <args>     direct git log --oneline --decorate <args>
 # ---------------------------------------------------------------------------
 function gl() {
+  case "${1:-}" in
+    help|-h|--help) gl-usage; return 0 ;;
+  esac
+
   if [[ $# -gt 0 ]]; then
     git log --oneline --decorate "$@"
     return
@@ -154,12 +202,23 @@ function glo() {
   gl "$@"
 }
 
+function gbinfo-usage() {
+  echo "gbinfo - branch tracking summary"
+  echo
+  echo "Usage:"
+  echo "  gbinfo [pattern...]  list local branches and upstream state"
+}
+
 # ---------------------------------------------------------------------------
 # gbinfo - list local git branches and their upstream tracking state
 #
 # Usage: gbinfo [pattern...]
 # ---------------------------------------------------------------------------
 function gbinfo() {
+  case "${1:-}" in
+    help|-h|--help) gbinfo-usage; return 0 ;;
+  esac
+
   local -a patterns
   if (( $# > 0 )); then
     patterns=("$@")
@@ -212,24 +271,35 @@ function gbinfo() {
   fi
 }
 
+function git-exclude-usage() {
+  echo "git-exclude - add repo-local ignore patterns"
+  echo
+  echo "Usage:"
+  echo "  git-exclude <pattern> [pattern...]"
+}
+
 # ---------------------------------------------------------------------------
 # git-exclude - add a pattern to the repo's local git exclude file
 #
-# Invocable as: git exclude <pattern>
+# Invocable as: git-exclude <pattern>
 #
 # Usage:
-#   git exclude <pattern> [pattern...]   e.g. git exclude .env.local .envrc
+#   git-exclude <pattern> [pattern...]   e.g. git-exclude .env.local .envrc
 # ---------------------------------------------------------------------------
 function git-exclude() {
+  case "${1:-}" in
+    help|-h|--help) git-exclude-usage; return 0 ;;
+  esac
+
   if (( $# == 0 )); then
-    echo "usage: git exclude <pattern> [pattern...]"
+    git-exclude-usage
     return 1
   fi
 
   local git_dir
   git_dir="$(git rev-parse --git-dir 2>/dev/null)"
   if [[ -z "$git_dir" ]]; then
-    echo "git exclude: not in a git repository"
+    echo "git-exclude: not in a git repository"
     return 1
   fi
 
@@ -239,11 +309,11 @@ function git-exclude() {
 
   for pattern in "$@"; do
     if grep -qxF "$pattern" "$exclude_file" 2>/dev/null; then
-      echo "git exclude: '$pattern' is already in $exclude_file"
+      echo "git-exclude: '$pattern' is already in $exclude_file"
       continue
     fi
 
     echo "$pattern" >> "$exclude_file"
-    echo "git exclude: added '$pattern' to $exclude_file"
+    echo "git-exclude: added '$pattern' to $exclude_file"
   done
 }

--- a/zsh/k8s.zsh
+++ b/zsh/k8s.zsh
@@ -4,6 +4,16 @@
 
 alias k="kubectl"
 
+function kctx-usage() {
+  echo "kctx - kubectl context switcher"
+  echo
+  echo "Usage:"
+  echo "  kctx           open the context picker"
+  echo "  kctx <name>    switch directly to a context"
+  echo "  kctx -         switch to the previous context"
+  echo "  kctx -d [name] delete a context"
+}
+
 # ---------------------------------------------------------------------------
 # kctx - switch kubectl context, with fzf picker when no args given
 #
@@ -14,6 +24,10 @@ alias k="kubectl"
 #   kctx -d [name]    delete context (fzf picker if no name given)
 # ---------------------------------------------------------------------------
 function kctx() {
+  case "${1:-}" in
+    help|-h|--help) kctx-usage; return 0 ;;
+  esac
+
   local current
   current="$(kubectl config current-context 2>/dev/null)"
 

--- a/zsh/local.example.zsh
+++ b/zsh/local.example.zsh
@@ -12,8 +12,8 @@
 # Advanced module selection.
 # Set these before sourcing init.zsh from your own ~/.zshrc if you want them
 # to affect which shared modules load.
-# typeset -ga ZSH_CONFIG_DISABLED_MODULES=(k8s ws)
-# typeset -ga ZSH_CONFIG_MODULES=(shell tools git search)
+# typeset -ga ZSH_CONFIG_DISABLED_MODULES=(k8s zt ws bm sec)
+# typeset -ga ZSH_CONFIG_MODULES=(shell tools git k8s til search zt ws bm sec)
 
 # Machine-specific or work-only settings belong here.
 # export WORKON_HOME="$HOME/venvs"

--- a/zsh/search.zsh
+++ b/zsh/search.zsh
@@ -2,6 +2,13 @@
 # SEARCH FUNCTIONS (rg + fzf)
 # ============================================================
 
+function rgg-usage() {
+  echo "rgg - live ripgrep picker"
+  echo
+  echo "Usage:"
+  echo "  rgg [query]  search the current directory and open a match"
+}
+
 # ---------------------------------------------------------------------------
 # rgg - live interactive grep across files in the current directory
 #
@@ -12,6 +19,10 @@
 # Enter opens your configured editor at the exact matched line.
 # ---------------------------------------------------------------------------
 function rgg() {
+  case "${1:-}" in
+    help|-h|--help) rgg-usage; return 0 ;;
+  esac
+
   local query="${*:-}"
   local initial_cmd="rg --column --line-number --no-heading --color=always --smart-case"
   local result file line
@@ -36,6 +47,13 @@ function rgg() {
   _zsh_toolkit_open_in_editor +"$line" "$file"
 }
 
+function ff-usage() {
+  echo "ff - fuzzy file finder"
+  echo
+  echo "Usage:"
+  echo "  ff [pattern]  pick a file in the current directory tree"
+}
+
 # ---------------------------------------------------------------------------
 # ff - find files by name using rg + fzf
 #
@@ -46,6 +64,10 @@ function rgg() {
 # Enter opens the selected file in your configured editor.
 # ---------------------------------------------------------------------------
 function ff() {
+  case "${1:-}" in
+    help|-h|--help) ff-usage; return 0 ;;
+  esac
+
   local file
 
   if [[ -n "$1" ]]; then

--- a/zsh/shell.zsh
+++ b/zsh/shell.zsh
@@ -14,6 +14,14 @@ export PATH="$HOME/.local/bin:$PATH"
 alias resource="source ~/.zshrc"
 alias tf="terraform"
 
+function falias-usage() {
+  echo "falias - fuzzy alias picker"
+  echo
+  echo "Usage:"
+  echo "  falias         open the alias picker"
+  echo "  falias --help  show help"
+}
+
 # ---------------------------------------------------------------------------
 # falias - fuzzy alias picker
 #
@@ -23,6 +31,10 @@ alias tf="terraform"
 #                 Ctrl-y copies expansion to clipboard
 # ---------------------------------------------------------------------------
 function falias() {
+  case "${1:-}" in
+    help|-h|--help) falias-usage; return 0 ;;
+  esac
+
   local out action sel expansion
   local -a lines=()
 
@@ -51,6 +63,14 @@ function falias() {
   fi
 }
 
+function fenv-usage() {
+  echo "fenv - fuzzy environment picker"
+  echo
+  echo "Usage:"
+  echo "  fenv         open the exported environment picker"
+  echo "  fenv --help  show help"
+}
+
 # ---------------------------------------------------------------------------
 # fenv - fuzzy env var picker
 #
@@ -60,6 +80,10 @@ function falias() {
 #                 Ctrl-e re-exports the var in the current shell
 # ---------------------------------------------------------------------------
 function fenv() {
+  case "${1:-}" in
+    help|-h|--help) fenv-usage; return 0 ;;
+  esac
+
   local out action line key val
   local -a lines=()
 

--- a/zsh/ws.zsh
+++ b/zsh/ws.zsh
@@ -81,7 +81,7 @@ function ws() {
     info)   ws-info "${@:2}" ;;
     rename) ws-rename "${@:2}" ;;
     cd)     ws-cd "${@:2}" ;;
-    help)   ws-help "${@:2}" ;;
+    help|-h|--help) ws-usage "${@:2}" ;;
     -n|-p|[^-]*)
       ws-new "$@"
       ;;
@@ -202,7 +202,7 @@ function ws-info() {
 }
 
 # ---------------------------------------------------------------------------
-# ws-help - display usage information
+# ws-usage - display usage information
 #
 # Usage: ws help [subcommand]
 # ---------------------------------------------------------------------------
@@ -232,10 +232,6 @@ function ws-usage() {
     help)   echo "usage: ws help [subcommand]" ;;
     *)      echo "ws: unknown subcommand: $1"; return 1 ;;
   esac
-}
-
-function ws-help() {
-  ws-usage "$@"
 }
 
 # ---------------------------------------------------------------------------

--- a/zsh/zt.zsh
+++ b/zsh/zt.zsh
@@ -2,6 +2,29 @@
 # ZSH TOOLKIT HELP SURFACE (zt)
 # ============================================================
 
+typeset -ga _ZT_HELP_MODULES=(
+  ws
+  bm
+  sec
+  til
+  shell
+  git
+  search
+  k8s
+)
+
+typeset -gA _ZT_HELP_MODULE_LABELS
+_ZT_HELP_MODULE_LABELS=(
+  ws     "Workspace"
+  bm     "Bookmarks"
+  sec    "Secrets"
+  til    "Notes"
+  shell  "Shell"
+  git    "Git"
+  search "Search"
+  k8s    "Kubernetes"
+)
+
 typeset -ga _ZT_HELP_COMMANDS=(
   ws
   bm
@@ -12,32 +35,89 @@ typeset -ga _ZT_HELP_COMMANDS=(
   todov
   tils
   todos
+  falias
+  fenv
+  gco
+  ga
+  gd
+  gl
+  gbinfo
+  git-exclude
+  rgg
+  ff
+  kctx
+)
+
+typeset -gA _ZT_HELP_MODULE
+_ZT_HELP_MODULE=(
+  ws            ws
+  bm            bm
+  sec           sec
+  til           til
+  tilv          til
+  todo          til
+  todov         til
+  tils          til
+  todos         til
+  falias        shell
+  fenv          shell
+  gco           git
+  ga            git
+  gd            git
+  gl            git
+  gbinfo        git
+  git-exclude   git
+  rgg           search
+  ff            search
+  kctx          k8s
 )
 
 typeset -gA _ZT_HELP_DESCRIPTIONS
 _ZT_HELP_DESCRIPTIONS=(
-  ws    "workspace manager"
-  bm    "bookmarks"
-  sec   "secrets"
-  til   "open or create a TIL note"
-  tilv  "view a TIL note"
-  todo  "open or create a TODO note"
-  todov "view a TODO note"
-  tils  "search TIL notes"
-  todos "search TODO notes"
+  ws            "workspace manager"
+  bm            "bookmarks"
+  sec           "secrets"
+  til           "open or create a TIL note"
+  tilv          "view a TIL note"
+  todo          "open or create a TODO note"
+  todov         "view a TODO note"
+  tils          "search TIL notes"
+  todos         "search TODO notes"
+  falias        "browse aliases with fzf"
+  fenv          "browse exported env vars with fzf"
+  gco           "check out a branch"
+  ga            "stage files"
+  gd            "inspect diffs"
+  gl            "browse git history"
+  gbinfo        "show branch tracking state"
+  git-exclude   "add repo-local ignore patterns"
+  rgg           "search files with ripgrep + fzf"
+  ff            "find files with ripgrep + fzf"
+  kctx          "switch kubectl contexts"
 )
 
 typeset -gA _ZT_HELP_USAGE
 _ZT_HELP_USAGE=(
-  ws    "ws-usage"
-  bm    "bm-usage"
-  sec   "sec-usage"
-  til   "til-usage"
-  tilv  "tilv-usage"
-  todo  "todo-usage"
-  todov "todov-usage"
-  tils  "tils-usage"
-  todos "todos-usage"
+  ws            "ws-usage"
+  bm            "bm-usage"
+  sec           "sec-usage"
+  til           "til-usage"
+  tilv          "tilv-usage"
+  todo          "todo-usage"
+  todov         "todov-usage"
+  tils          "tils-usage"
+  todos         "todos-usage"
+  falias        "falias-usage"
+  fenv          "fenv-usage"
+  gco           "gco-usage"
+  ga            "ga-usage"
+  gd            "gd-usage"
+  gl            "gl-usage"
+  gbinfo        "gbinfo-usage"
+  git-exclude   "git-exclude-usage"
+  rgg           "rgg-usage"
+  ff            "ff-usage"
+  kctx          "kctx-usage"
 )
 
 function zt() {
@@ -59,31 +139,45 @@ function zt-help() {
   emulate -L zsh
 
   if [[ $# -eq 0 ]]; then
-    local cmd usage
+    local module cmd usage
+    local -i printed=0
 
     echo "zt - zsh toolkit"
     echo
     echo "Usage: zt help [command]"
     echo
-    echo "Commands:"
-    for cmd in "${_ZT_HELP_COMMANDS[@]}"; do
-      usage="${_ZT_HELP_USAGE[$cmd]}"
-      whence -w "$usage" >/dev/null 2>&1 || continue
-      printf "  %-8s %s\n" "$cmd" "${_ZT_HELP_DESCRIPTIONS[$cmd]}"
+    for module in "${_ZT_HELP_MODULES[@]}"; do
+      printed=0
+
+      for cmd in "${_ZT_HELP_COMMANDS[@]}"; do
+        [[ "${_ZT_HELP_MODULE[$cmd]}" == "$module" ]] || continue
+
+        usage="${_ZT_HELP_USAGE[$cmd]}"
+        whence -w "$usage" >/dev/null 2>&1 || continue
+
+        if (( ! printed )); then
+          echo "${_ZT_HELP_MODULE_LABELS[$module]}:"
+          printed=1
+        fi
+
+        printf "  %-12s %s\n" "$cmd" "${_ZT_HELP_DESCRIPTIONS[$cmd]}"
+      done
+
+      (( printed )) && echo
     done
-    echo
     echo "Run 'zt help <command>' for command-specific usage."
     return 0
   fi
 
-  local usage_func="${_ZT_HELP_USAGE[$1]}"
+  local command="${(j: :)@}"
+  local usage_func="${_ZT_HELP_USAGE[$command]}"
   if [[ -z "$usage_func" ]]; then
-    echo "zt: unknown command: $1"
+    echo "zt: unknown command: $command"
     return 1
   fi
 
   if ! whence -w "$usage_func" >/dev/null 2>&1; then
-    echo "zt: help unavailable for: $1"
+    echo "zt: help unavailable for: $command"
     return 1
   fi
 


### PR DESCRIPTION
## Summary
- sync README and local module examples with current defaults
- expand zt help coverage for shell, git, search, and k8s commands
- simplify ws help routing and remove the redundant wrapper

## Validation
- zsh -n on touched modules
- smoke-tested zt help and command-specific help entrypoints
