### PR TITLE
docs(ws): document tmux login shell requirement on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,3 +119,15 @@ source ~/Projects/zsh-toolkit/init.zsh
 - `terraform`
 
 The install script currently supports macOS + Homebrew only.
+
+## tmux setup (macOS)
+
+On macOS, new tmux sessions do not source `/etc/zprofile`, so `path_helper` never runs and PATH is nearly empty — tools like `fzf` and even `grep` will not be found inside sessions created by `ws`.
+
+Add this to `~/.tmux.conf` to start all panes as login shells:
+
+```
+set-option -g default-command "zsh -l"
+```
+
+Then reload tmux config (`tmux source ~/.tmux.conf`) or restart tmux.

--- a/zsh/ws.zsh
+++ b/zsh/ws.zsh
@@ -219,6 +219,9 @@ function ws-usage() {
     done
     echo
     echo "  ws <name> [path]   create or attach to a named session"
+    echo
+    echo "Note (macOS): add 'set-option -g default-command \"zsh -l\"' to ~/.tmux.conf"
+    echo "  so new sessions inherit a full PATH. See README for details."
     return 0
   fi
 


### PR DESCRIPTION
## Summary
- New tmux sessions on macOS skip `/etc/zprofile`, so `path_helper` never runs and PATH is nearly empty — causing `fzf`, `grep`, and other tools to not be found inside `ws`-created sessions.
- Documents the fix (`set-option -g default-command "zsh -l"` in `~/.tmux.conf`) in the README and as an inline note in `ws help` output.

Closes #22

## Why docs and not a code fix in ws.zsh
Hardcoding `-- zsh -l` in `tmux new-session` would fix `ws`-created sessions only, break users on non-zsh shells, and give false confidence while leaving all other tmux sessions still broken. The root cause is a macOS + tmux interaction that affects everything; the right fix is a one-liner in `~/.tmux.conf` that solves it globally.

## Test plan
- [ ] Run `ws <name>` to create a new session, attach, and confirm `fzf` and `grep` are on PATH after adding the tmux.conf line
- [ ] Run `ws help` and confirm the macOS note is visible
- [ ] Verify README renders correctly on GitHub