### PR TITLE
fix(#27): restore Ctrl-D delete binding in bm picker

### DIFF
--- a/zsh/bm.zsh
+++ b/zsh/bm.zsh
@@ -48,7 +48,7 @@ function _bm_pick() {
           --delimiter='=' \
           --header='Enter: cd | Ctrl-d: delete bookmark | Ctrl-y: copy path' \
           --exit-0 \
-          --bind="ctrl-d:execute-silent(zsh -fc 'ZSH_CONFIG_ROOT=\"\$1\"; source \"\$ZSH_CONFIG_ROOT/zsh/bm.zsh\"; _bm_delete_entry \"\$2\"' _ \"$ZSH_CONFIG_ROOT\" \"{1}\")+reload(grep -v '^[[:space:]]*#' \"$BM_FILE\")" \
+          --bind="ctrl-d:execute-silent(zsh -fc 'ZSH_CONFIG_ROOT=\"\$1\"; source \"\$ZSH_CONFIG_ROOT/zsh/state.zsh\"; source \"\$ZSH_CONFIG_ROOT/zsh/bm.zsh\"; _bm_delete_entry \"\$2\"' _ \"$ZSH_CONFIG_ROOT\" \"{1}\")+reload(grep -v '^[[:space:]]*#' \"$BM_FILE\")" \
           --bind="ctrl-y:execute-silent(printf '%s' {2..} | pbcopy)+abort" \
           --preview='rg --files "$(cut -d= -f2- <<< {})" 2>/dev/null | head -50')
   [[ -z "$line" ]] && return


### PR DESCRIPTION
## Summary
- fix the `bm` Ctrl-D picker action so it can delete the selected bookmark
- load `state.zsh` in the Ctrl-D subprocess before calling `_bm_delete_entry`

## Root cause
The `Ctrl-D` binding launched a fresh `zsh -fc` process that sourced `bm.zsh` only. `_bm_delete_entry` depends on `_zsh_toolkit_kv_update_file` from `state.zsh`, so the delete path failed inside the silent subprocess and the picker never updated.

fixes #27
