### PR TITLE
feat: add plugins, zoxide, history options, and keybindings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ zsh/local.zsh
 zsh/local.d/
 zsh/bookmarks
 zsh/secrets
+plugins/

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+ZSH_TOOLKIT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+
 packages=(
   fzf
   bat
@@ -10,6 +12,7 @@ packages=(
   starship
   mise
   terraform
+  zoxide
 )
 
 if [[ "$(uname -s)" != "Darwin" ]]; then
@@ -28,3 +31,23 @@ brew install "${packages[@]}"
 
 printf '\nInstalled packages:\n'
 printf '  - %s\n' "${packages[@]}"
+
+# --- Plugins ---
+_plugin_install() {
+  local name="$1" url="$2"
+  local dest="$ZSH_TOOLKIT_DIR/plugins/$name"
+  if [[ -d "$dest" ]]; then
+    printf '  updating %s\n' "$name"
+    git -C "$dest" pull --ff-only
+  else
+    printf '  cloning %s\n' "$name"
+    git clone --depth=1 "$url" "$dest"
+  fi
+}
+
+printf '\nInstalling zsh plugins:\n'
+_plugin_install fzf-tab             https://github.com/Aloxaf/fzf-tab
+_plugin_install zsh-autosuggestions  https://github.com/zsh-users/zsh-autosuggestions
+_plugin_install zsh-syntax-highlighting https://github.com/zsh-users/zsh-syntax-highlighting
+
+printf '\nDone.\n'

--- a/zsh/shell.zsh
+++ b/zsh/shell.zsh
@@ -7,6 +7,17 @@ export GPG_TTY="$(tty)"
 export HISTIGNORE="pwd:ls:cd:ll"
 export DISABLE_AUTO_TITLE="true"
 
+# --- History ---
+HISTSIZE=10000
+HISTFILE="${HISTFILE:-$HOME/.zsh_history}"
+SAVEHIST=$HISTSIZE
+setopt APPEND_HISTORY
+setopt HIST_IGNORE_ALL_DUPS
+setopt HIST_SAVE_NO_DUPS
+setopt HIST_IGNORE_DUPS
+setopt HIST_FIND_NO_DUPS
+setopt HIST_REDUCE_BLANKS
+
 # --- Paths ---
 export PATH="$HOME/.local/bin:$PATH"
 

--- a/zsh/tools.zsh
+++ b/zsh/tools.zsh
@@ -25,3 +25,32 @@ fi
 
 autoload -Uz compinit
 compinit
+
+# --- Keybindings ---
+bindkey -e
+bindkey '^p' history-search-backward
+bindkey '^n' history-search-forward
+
+# --- Completion styling ---
+zstyle ':completion:*' menu select
+zstyle ':completion:*' matcher-list 'm:{a-z}={A-Za-z}'
+zstyle ':completion:*' list-colors "${(s.:.)LS_COLORS}"
+
+# --- Plugins (installed via scripts/install.sh) ---
+# fzf-tab must come after compinit and after fzf --zsh (so it can override Tab)
+[[ -f "$ZSH_CONFIG_ROOT/plugins/fzf-tab/fzf-tab.plugin.zsh" ]] && \
+  source "$ZSH_CONFIG_ROOT/plugins/fzf-tab/fzf-tab.plugin.zsh"
+
+[[ -f "$ZSH_CONFIG_ROOT/plugins/zsh-autosuggestions/zsh-autosuggestions.zsh" ]] && \
+  source "$ZSH_CONFIG_ROOT/plugins/zsh-autosuggestions/zsh-autosuggestions.zsh"
+
+# zsh-syntax-highlighting must be sourced last
+[[ -f "$ZSH_CONFIG_ROOT/plugins/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh" ]] && \
+  source "$ZSH_CONFIG_ROOT/plugins/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh"
+
+# --- Zoxide ---
+# cd is replaced by zoxide; z is a shorthand alias
+if command -v zoxide >/dev/null 2>&1; then
+  eval "$(zoxide init --cmd cd zsh)"
+  alias z='cd'
+fi


### PR DESCRIPTION
## Summary
- Add zsh plugin support via `git clone` into `plugins/` (fzf-tab, zsh-autosuggestions, zsh-syntax-highlighting) — installed by `scripts/install.sh`, sourced conditionally in `tools.zsh`
- Add zoxide integration (`cd` is zoxide-powered, `z` alias provided)
- Add history dedup and size options (`HISTSIZE=10000`, `HIST_IGNORE_ALL_DUPS`, etc.)
- Switch to emacs keybindings (`bindkey -e`) with `^p`/`^n` prefix history search
- Add completion styling (`menu select`, case-insensitive, LS_COLORS)

## Test plan
- [ ] Run `scripts/install.sh` and confirm plugins are cloned into `plugins/`
- [ ] `source ~/.zshrc` — no errors
- [ ] Press Tab mid-command — fzf-tab picker appears
- [ ] Type partial command, press `^p` — prefix history search works
- [ ] `z <partial>` or `cd <partial>` — zoxide navigates
- [ ] Run duplicate commands, check `history` — deduplication working
- [ ] `Ctrl-W`, Delete, `Ctrl-A` all work as expected